### PR TITLE
add kotlin-reflect to stop app break on remote-click

### DIFF
--- a/android-example/build.gradle.kts
+++ b/android-example/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.rewedigital.katana:katana-androidx-viewmodel-savedstate:1.7.0-alpha01")
     implementation("androidx.appcompat:appcompat:1.0.2")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.3.31")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.2.1")
     implementation("org.jetbrains.anko:anko-coroutines:0.10.8")


### PR DESCRIPTION
On Android 9, API 28 the example-app breaks on clicking "REMOTE" 