### PR TITLE
Alias functionality

### DIFF
--- a/Getting Started.md
+++ b/Getting Started.md
@@ -191,9 +191,9 @@ a repository to your project. Then add the following dependencies:
 
 ```gradle
 dependencies {
-    implementation 'org.rewedigital.katana:katana-core:1.8.3'
+    implementation 'org.rewedigital.katana:katana-core:1.9.0'
     // Use this artifact for Katana on Android
-    implementation 'org.rewedigital.katana:katana-android:1.8.3'
+    implementation 'org.rewedigital.katana:katana-android:1.9.0'
 }
 ```
 

--- a/android-example/build.gradle.kts
+++ b/android-example/build.gradle.kts
@@ -22,15 +22,15 @@ android {
 
         applicationId = "org.rewedigital.katana.android.example"
         versionCode = 1
-        versionName = "1.8.3"
+        versionName = "1.9.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 }
 
 dependencies {
-    implementation("org.rewedigital.katana:katana-android:1.8.3")
-    implementation("org.rewedigital.katana:katana-androidx-viewmodel-savedstate:1.8.3-beta01")
+    implementation("org.rewedigital.katana:katana-android:1.9.0")
+    implementation("org.rewedigital.katana:katana-androidx-viewmodel-savedstate:1.9.0-beta01")
     implementation("androidx.appcompat:appcompat:1.1.0")
     implementation("androidx.constraintlayout:constraintlayout:1.1.3")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.3.50")

--- a/androidx-viewmodel-savedstate/build.gradle.kts
+++ b/androidx-viewmodel-savedstate/build.gradle.kts
@@ -8,7 +8,7 @@ configureBase(
     publicationComponent = components["android"]
 )
 
-version = "1.8.3-beta01"
+version = "1.9.0-beta01"
 
 dependencies {
     api(project(":core"))

--- a/buildSrc/src/main/kotlin/BaseProject.kt
+++ b/buildSrc/src/main/kotlin/BaseProject.kt
@@ -39,7 +39,7 @@ fun Project.configureBase(
     }
 
     group = "org.rewedigital.katana"
-    version = "1.8.3"
+    version = "1.9.0"
 
     tasks.withType<Jar> {
         archiveBaseName.set(artifactName)

--- a/core/src/main/kotlin/org/rewedigital/katana/Component.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/Component.kt
@@ -175,6 +175,8 @@ class Component(
      * @see inject
      * @throws InjectionException
      * @throws InstanceCreationException
+     *
+     * TODO: Rename to get()?
      */
     inline fun <reified T> injectNow(name: Any? = null) =
         context.injectNow<T>(name)
@@ -312,6 +314,7 @@ class ComponentContext private constructor(
         injectNow<T>(name = name, internal = internal)
     }
 
+    // TODO: Rename to get()?
     inline fun <reified T> injectNow(name: Any? = null, internal: Boolean = false) =
         injectByKey<T>(key = Key.of(T::class.java, name), internal = internal)
 

--- a/core/src/main/kotlin/org/rewedigital/katana/KatanaTrait.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/KatanaTrait.kt
@@ -27,6 +27,8 @@ inline fun <reified T> KatanaTrait.inject(name: Any? = null) =
 
 /**
  * @see Component.injectNow
+ *
+ * TODO: Rename to get()?
  */
 inline fun <reified T> KatanaTrait.injectNow(name: Any? = null) =
     withComponent { injectNow<T>(name) }

--- a/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
@@ -83,11 +83,11 @@ inline fun <reified T> ModuleBindingContext.eagerSingleton(
  * Declares an alias of type [A] with optional [name] of an already existing binding of type [T] with optional name
  * [originalName]. An alias is accomplished by and nothing else than a simple [factory] binding.
  *
- * A binding like `alias<MyClass, MyInterface>()` should be conceived as "alias MyClass as MyInterface".
+ * A binding like `alias<MyInterface, MyClass>()` should be conceived as "create alias MyInterface for MyClass".
  */
-inline fun <reified T : A, reified A> ModuleBindingContext.alias(
-    originalName: String? = null,
-    name: String? = null
+inline fun <reified A, reified T : A> ModuleBindingContext.alias(
+    name: String? = null,
+    originalName: String? = null
 ) {
     factory<A>(name = name) { get<T>(name = originalName) }
 }

--- a/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
@@ -1,7 +1,7 @@
 package org.rewedigital.katana.dsl
 
 import org.rewedigital.katana.*
-import org.rewedigital.katana.dsl.internal.moduleDeclaration
+import org.rewedigital.katana.dsl.internal.declaration
 
 /**
  * Declares a dependency binding.
@@ -19,7 +19,7 @@ inline fun <reified T> ModuleBindingContext.factory(
     internal: Boolean = false,
     noinline body: ProviderDsl.() -> T
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = name,
@@ -44,7 +44,7 @@ inline fun <reified T> ModuleBindingContext.singleton(
     internal: Boolean = false,
     noinline body: ProviderDsl.() -> T
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = name,
@@ -70,7 +70,7 @@ inline fun <reified T> ModuleBindingContext.eagerSingleton(
     internal: Boolean = false,
     noinline body: ProviderDsl.() -> T
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = name,
@@ -153,7 +153,7 @@ internal inline fun <reified T, reified S : Set<T>> ModuleBindingContext.interna
             module = module,
             key = Key.of(clazz = T::class.java, name = name)
         ).let { bindingContext ->
-            moduleDeclaration(
+            declaration(
                 context = this,
                 clazz = S::class.java,
                 name = name,
@@ -169,7 +169,7 @@ internal inline fun <reified T, reified S : Set<T>> ModuleBindingContext.interna
 inline fun <reified T> SetBindingContext<T>.factory(
     noinline body: ProviderDsl.() -> T
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = null,
@@ -181,7 +181,7 @@ inline fun <reified T> SetBindingContext<T>.factory(
 inline fun <reified T> SetBindingContext<T>.singleton(
     noinline body: ProviderDsl.() -> T
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = null,
@@ -189,6 +189,26 @@ inline fun <reified T> SetBindingContext<T>.singleton(
         type = Declaration.Type.SINGLETON,
         provider = DefaultProvider(body)
     )
+
+/**
+ * Adds an already declared dependency in the context of the [Module] to this [Set].
+ *
+ * @param T type of the set
+ * @param V type of the value added to the set
+ */
+inline fun <T, reified V : T> SetBindingContext<T>.get(
+    name: String? = null
+) = declaration(
+    context = this,
+    clazz = V::class.java,
+    name = name,
+    internal = false,
+    type = Declaration.Type.CUSTOM,
+    provider = object : Provider<V> {
+        override fun invoke(context: ComponentContext, arg: Any?): V =
+            context.injectNow(name = name)
+    }
+)
 
 /**
  * Declares a custom binding with a custom implementation of [Provider].
@@ -203,7 +223,7 @@ inline fun <reified T> ModuleBindingContext.custom(
     internal: Boolean = false,
     provider: Provider<T>
 ) =
-    moduleDeclaration(
+    declaration(
         context = this,
         clazz = T::class.java,
         name = name,

--- a/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/dsl/Dsl.kt
@@ -80,6 +80,19 @@ inline fun <reified T> ModuleBindingContext.eagerSingleton(
     )
 
 /**
+ * Declares an alias of type [A] with optional [name] of an already existing binding of type [T] with optional name
+ * [originalName]. An alias is accomplished by and nothing else than a simple [factory] binding.
+ *
+ * A binding like `alias<MyClass, MyInterface>()` should be conceived as "alias MyClass as MyInterface".
+ */
+inline fun <reified T : A, reified A> ModuleBindingContext.alias(
+    originalName: String? = null,
+    name: String? = null
+) {
+    factory<A>(name = name) { get<T>(name = originalName) }
+}
+
+/**
  * Declares a [Set] based multi-binding.
  *
  * Each [SetBindingContext.factory] or [SetBindingContext.singleton] declaration inside `set { }` contributes

--- a/core/src/main/kotlin/org/rewedigital/katana/dsl/classic/ClassicDsl.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/dsl/classic/ClassicDsl.kt
@@ -6,7 +6,7 @@ import org.rewedigital.katana.DefaultProvider
 import org.rewedigital.katana.ModuleBindingContext
 import org.rewedigital.katana.dsl.ModuleDslMarker
 import org.rewedigital.katana.dsl.ProviderDsl
-import org.rewedigital.katana.dsl.internal.moduleDeclaration
+import org.rewedigital.katana.dsl.internal.declaration
 
 /**
  * Declares a dependency binding.
@@ -52,7 +52,7 @@ class BindingDsl<T>(
         type: Type,
         body: ProviderDsl.() -> T
     ) =
-        moduleDeclaration(
+        declaration(
             context = context,
             clazz = clazz,
             name = name,

--- a/core/src/main/kotlin/org/rewedigital/katana/dsl/internal/Internal.kt
+++ b/core/src/main/kotlin/org/rewedigital/katana/dsl/internal/Internal.kt
@@ -3,7 +3,7 @@ package org.rewedigital.katana.dsl.internal
 import org.rewedigital.katana.*
 
 @PublishedApi
-internal fun <CTX : BindingContext, T> moduleDeclaration(
+internal fun <CTX : BindingContext, T> declaration(
     context: CTX,
     clazz: Class<T>,
     name: Any?,

--- a/core/src/test/kotlin/org/rewedigital/katana/AliasTests.kt
+++ b/core/src/test/kotlin/org/rewedigital/katana/AliasTests.kt
@@ -1,0 +1,50 @@
+package org.rewedigital.katana
+
+import org.amshove.kluent.shouldBe
+import org.rewedigital.katana.dsl.alias
+import org.rewedigital.katana.dsl.singleton
+import org.spekframework.spek2.Spek
+import org.spekframework.spek2.style.specification.describe
+
+object AliasTests : Spek(
+    {
+        describe("Alias bindings") {
+
+            it("should provide aliases for class bindings") {
+
+                val module = Module {
+
+                    singleton { MyComponentA() }
+
+                    alias<MyComponentA, MyComponent>()
+                }
+
+                val component = Component(module)
+
+                val myComponentA: MyComponentA by component.inject()
+                val myComponent: MyComponent by component.inject()
+
+                myComponent shouldBe myComponentA
+            }
+
+            it("should provide aliases for named bindings") {
+
+                val module = Module {
+
+                    singleton(name = "original name") { MyComponentA() }
+
+                    alias<MyComponentA, MyComponent>(
+                        originalName = "original name",
+                        name = "alias name"
+                    )
+                }
+
+                val component = Component(module)
+
+                val myComponentA: MyComponentA by component.inject(name = "original name")
+                val myComponent: MyComponent by component.inject(name = "alias name")
+
+                myComponent shouldBe myComponentA
+            }
+        }
+    })

--- a/core/src/test/kotlin/org/rewedigital/katana/AliasTests.kt
+++ b/core/src/test/kotlin/org/rewedigital/katana/AliasTests.kt
@@ -16,7 +16,7 @@ object AliasTests : Spek(
 
                     singleton { MyComponentA() }
 
-                    alias<MyComponentA, MyComponent>()
+                    alias<MyComponent, MyComponentA>()
                 }
 
                 val component = Component(module)
@@ -33,9 +33,9 @@ object AliasTests : Spek(
 
                     singleton(name = "original name") { MyComponentA() }
 
-                    alias<MyComponentA, MyComponent>(
-                        originalName = "original name",
-                        name = "alias name"
+                    alias<MyComponent, MyComponentA>(
+                        name = "alias name",
+                        originalName = "original name"
                     )
                 }
 

--- a/core/src/test/kotlin/org/rewedigital/katana/SetTests.kt
+++ b/core/src/test/kotlin/org/rewedigital/katana/SetTests.kt
@@ -172,7 +172,7 @@ object SetTests : Spek(
                 count2 shouldEqual 1
             }
 
-            it("should locate dependencies declared in outer scope") {
+            it("should locate dependencies declared in outer scope via factory") {
                 val module = Module {
                     factory(name = "outer scope") { "Hello world" }
 
@@ -185,6 +185,27 @@ object SetTests : Spek(
 
                 set shouldHaveSize 1
                 set shouldContain "Hello world"
+            }
+
+            it("should locate dependencies declared in outer scope via get") {
+                val module = Module {
+                    factory(name = "outer scope") { "Hello world" }
+                    singleton { "Another string" }
+                    factory<CharSequence> { "A char sequence" }
+
+                    set<CharSequence> {
+                        get<CharSequence, String>(name = "outer scope")
+                        get<CharSequence, String>()
+                        get()
+                    }
+                }
+                val component = Component(module)
+                val set: Set<String> = component.injectNow()
+
+                set shouldHaveSize 3
+                set shouldContain "Hello world"
+                set shouldContain "Another string"
+                set shouldContain "A char sequence"
             }
         }
     })


### PR DESCRIPTION
Provides an `alias` binding which is nothing more than a simplified `factory` binding of an already existing binding under a different class or name.

**Update:** Also added `get` binding for `set` which adds an already declared dependency in the context of the module to a set.